### PR TITLE
chore: fixed android sdk token expriy logic, allowed empty setting fo…

### DIFF
--- a/android/src/main/java/com/stallion/storage/StallionConfig.java
+++ b/android/src/main/java/com/stallion/storage/StallionConfig.java
@@ -119,12 +119,10 @@ public class StallionConfig {
   }
 
   public void updateSdkToken(String newApiKey) {
-    if(!newApiKey.isEmpty()) {
       this.sdkToken = newApiKey;
       SharedPreferences.Editor editor = sharedPreferences.edit();
       editor.putString(StallionConfigConstants.API_KEY_IDENTIFIER, this.sdkToken);
       editor.apply();
-    }
   }
 
   public String getAppToken() {


### PR DESCRIPTION
Android - Allowed SDK token expiry by allowing empty string resetting. Removed non empty check from `updateSdkToken ` 