### PR TITLE
fix: remove RCT-Folly dependency from podspec as it is failing for newers versions of React Native

### DIFF
--- a/react-native-stallion.podspec
+++ b/react-native-stallion.podspec
@@ -37,7 +37,6 @@ Pod::Spec.new do |s|
         "CLANG_CXX_LANGUAGE_STANDARD" => "c++17"
     }
     s.dependency "React-Codegen"
-    s.dependency "RCT-Folly"
     s.dependency "RCTRequired"
     s.dependency "RCTTypeSafety"
     s.dependency "ReactCommon/turbomodule/core"


### PR DESCRIPTION
In this, I have fixed the issue of failing to build the react native project for newer versions when new architecture is enabled as In RN 0.81+, RCT-Folly has been fully replaced by a new internal dependency system. 

Linked issue: #79 