### PR TITLE
fix releaseHash in stallion event type

### DIFF
--- a/src/main/state/useStallionEvents.ts
+++ b/src/main/state/useStallionEvents.ts
@@ -33,7 +33,7 @@ export interface IStallionNativeEventData {
   type: NativeEventTypesProd | NativeEventTypesStage;
   eventId: string;
   eventTimestamp: number;
-  releasehash?: string;
+  releaseHash?: string;
   error?: string;
   progress?: string;
 }


### PR DESCRIPTION
At runtime this is `releaseHash` many hours have been wasted trying to figure this out...