### PR TITLE
fix: android 16kb, removed react codegen block

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -103,11 +103,3 @@ dependencies {
   //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"
 }
-
-if (isNewArchitectureEnabled()) {
-  react {
-    jsRootDir = file("../src/")
-    libraryName = "Stallion"
-    codegenJavaPackageName = "com.stallion"
-  }
-}

--- a/android/src/main/cpp/CMakeLists.txt
+++ b/android/src/main/cpp/CMakeLists.txt
@@ -17,3 +17,9 @@ target_link_libraries(
   stallion-crash
   ${log-lib}
 )
+
+# Fix for 16KB page size compatibility (required for Android 15+)
+# This ensures LOAD segments are aligned at 16KB boundaries
+set_target_properties(stallion-crash PROPERTIES
+  LINK_FLAGS "-Wl,-z,max-page-size=16384"
+)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-stallion",
-  "version": "2.3.0",
+  "version": "2.3.1-alpha.1",
   "description": "Offical React Native SDK for Stallion",
   "main": "index",
   "types": "types/index.d.ts",


### PR DESCRIPTION
- Android 16Kb page size support
- Removed codegen for new arch