### PR TITLE
fix: handle empty restart intents in ProcessPhoenix

### DIFF
--- a/android/src/main/java/com/stallion/utils/ProcessPhoenix.java
+++ b/android/src/main/java/com/stallion/utils/ProcessPhoenix.java
@@ -72,6 +72,11 @@ public final class ProcessPhoenix extends Activity {
         Process.killProcess(getIntent().getIntExtra(KEY_MAIN_PROCESS_PID, -1)); // Kill original main process
 
         ArrayList<Intent> intents = getIntent().getParcelableArrayListExtra(KEY_RESTART_INTENTS);
+        if (intents == null || intents.isEmpty()) { // Relaunched by system without our extras
+            finish();
+            Runtime.getRuntime().exit(0);
+            return;
+        }
         startActivities(intents.toArray(new Intent[intents.size()]));
         finish();
         Runtime.getRuntime().exit(0); // Kill kill kill!


### PR DESCRIPTION
## What:
Fixes an Android crash on app restart.

## Crash:
NullPointerException: ... ArrayList.size() on a null object reference in ProcessPhoenix.onCreate.

## Why it happens:
 Stallion restarts the app by relaunching ProcessPhoenix with the next screens stored as an intent extra. When Android relaunches this activity on its own (after the process is killed/restored), the extra is missing → the intents list is null → .size() crashes.

## Fix:
 one guard — if there are no restart intents, just exit cleanly instead of crashing.

ArrayList<Intent> intents = getIntent().getParcelableArrayListExtra(KEY_RESTART_INTENTS);
if (intents == null || intents.isEmpty()) {
    finish();
    Runtime.getRuntime().exit(0);
    return;
}
<img width="1162" height="798" alt="Screenshot 2026-06-29 at 10 22 50 PM" src="https://github.com/user-attachments/assets/f1d6da85-a1d6-44fc-9e04-16cf16f304a3" />

## Risk:
 none on the normal path — the guard only triggers when the app was already going to crash.