### PR TITLE
Fix entrypoint pointing to an invalid index.js that does not exist causing issues with jest for example

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "react-native-stallion",
   "version": "2.4.1",
   "description": "Official React Native OTA updates SDK — CodePush alternative with patch updates, rollback, and bundle signing.",
-  "main": "index",
+  "main": "src/index",
   "types": "types/index.d.ts",
   "react-native": "src/index",
   "source": "src/index",


### PR DESCRIPTION
Update the package entry point so that node compatible resolvers and test runners (like jest) can locate the published js module correctly. This keeps Metro behaviour unchanged while making the package usable by Jest and other tooling that relies on the standard main field.

You can reproduce this by doing: 

```
jest.mock("react-native-stallion", () => ({
	__esModule: true,
	ACTIVE_RELEASE_HASH: null,
	withStallion: (Component) => Component,
	useStallionModal: () => ({ showModal: jest.fn() }),
}));
```

And will experience the following error: ` Cannot find module 'react-native-stallion' from...`